### PR TITLE
[feat] 로그 출력 형식 더욱 업그레이드

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -1,5 +1,6 @@
 import torch
 import io
+import threading
 from transformers import CLIPProcessor, CLIPModel
 from PIL import Image, ImageOps
 from logging import Logger
@@ -25,15 +26,15 @@ class Model:
             image_object = Image.open(image_data_stream)
             ImageOps.exif_transpose(image_object, in_place=True)
             elapsed = timer.stop()
-            self.logger.info(f"[Model.get_image_vector] Converting the bytes to PIL Image object took {elapsed:.3f} sec.")
+            self.logger.info(f"[{threading.get_ident()} - Model.get_image_vector] Converting the bytes to PIL Image object took {elapsed:.3f} sec.")
             timer.start()
             inputs = self.processor(images=image_object, return_tensors="pt").to(GPU)
             elapsed = timer.stop()
-            self.logger.info(f"[Model.get_image_vector] Converting PIL Image object to input tensor took {elapsed:.3f} sec.")
+            self.logger.info(f"[{threading.get_ident()} - Model.get_image_vector] Converting PIL Image object to input tensor took {elapsed:.3f} sec.")
             timer.start()
             image_features = self.model.get_image_features(**inputs)
             elapsed = timer.stop()
-            self.logger.info(f"[Model.get_image_vector] Calculating image features took {elapsed:.3f} sec.")
+            self.logger.info(f"[{threading.get_ident()} - Model.get_image_vector] Calculating image features took {elapsed:.3f} sec.")
         return image_features
 
     def get_text_vector(self, query: str):
@@ -42,9 +43,9 @@ class Model:
             timer.start()
             inputs = self.processor(text=[query], return_tensors="pt", padding=True).to(GPU)
             elapsed = timer.stop()
-            self.logger.info(f"[Model.get_text_vector] Converting string to input tensor took {elapsed:.3f} sec.")
+            self.logger.info(f"[{threading.get_ident()} - Model.get_text_vector] Converting string to input tensor took {elapsed:.3f} sec.")
             timer.start()
             text_features = self.model.get_text_features(**inputs)
             elapsed = timer.stop()
-            self.logger.info(f"[Model.get_text_vector] Calculating text features took {elapsed:.3f} sec.")
+            self.logger.info(f"[{threading.get_ident()} - Model.get_text_vector] Calculating text features took {elapsed:.3f} sec.")
         return text_features

--- a/src/server.py
+++ b/src/server.py
@@ -2,6 +2,7 @@ import os
 import requests
 import logging
 import click
+import threading
 
 from uvicorn.logging import AccessFormatter, DefaultFormatter
 
@@ -51,30 +52,30 @@ def upload_to_db(image_id):
             return {"status": "failed", "error_msg": "Error on communicating to image server."}
         data = response.content
     elapsed = timer.stop()
-    logger.info(f"[Upload] Loaded data of {image_id} from ImgDB ({elapsed:.3f} sec)")
+    logger.info(f"[{threading.get_ident()} - Upload] Loaded data of {image_id} from ImgDB ({elapsed:.3f} sec)")
     timer.start()
     vector = model.get_image_vector(data)
     elapsed = timer.stop()
-    logger.info(f"[Upload] Computed feature vector of {image_id} ({elapsed:.3f} sec)")
+    logger.info(f"[{threading.get_ident()} - Upload] Computed feature vector of {image_id} ({elapsed:.3f} sec)")
     timer.start()
     try:
         db.push(image_id, vector)
     except ValueError as e:
         return {"status": "failed", "error_msg": f"{type(e)}: {e}"}
     elapsed = timer.stop()
-    logger.info(f"[Upload] Uploaded feature vector of {image_id} ({elapsed:.3f} sec)")
+    logger.info(f"[{threading.get_ident()} - Upload] Uploaded feature vector of {image_id} ({elapsed:.3f} sec)")
     return {"status": "success"}
 
 @app.get("/api/count")
 def api_get_uploaded_images():
-    logger.info("====== /api/count ======", extra={"color_message": f"====== {click.style('/api/count', bold=True)} ======"})
+    logger.info(f"[{threading.get_ident()}] ====== /api/count ======", extra={"color_message": f"[{threading.get_ident()}] ====== {click.style('/api/count', bold=True)} ======"})
     content = {"count": db.count()}
-    logger.info(f"VecDB count = {content['count']}")
+    logger.info(f"[{threading.get_ident()}] VecDB count = {content['count']}")
     return JSONResponse(content=content)
 
 @app.post("/api/upload")
 def api_upload_image(image_ids: list[str] = Body(...)):
-    logger.info("====== /api/upload ======", extra={"color_message": f"====== {click.style('/api/upload', bold=True)} ======"})
+    logger.info(f"[{threading.get_ident()}] ====== /api/upload ======", extra={"color_message": f"[{threading.get_ident()}] ====== {click.style('/api/upload', bold=True)} ======"})
     resp_json = {"status": {"success": 0, "failed": 0}, "results": []}
     timer = SimpleTimer()
     timer.start()
@@ -83,18 +84,18 @@ def api_upload_image(image_ids: list[str] = Body(...)):
         subtimer.start()
         result = upload_to_db(image_id)
         elapsed = subtimer.stop()
-        logger.info(f"Uploaded {image_id} to VecDB : {result.get('error_msg', 'Success')} ({elapsed:.3f} sec)")
+        logger.info(f"[{threading.get_ident()}] Uploaded {image_id} to VecDB : {result.get('error_msg', 'Success')} ({elapsed:.3f} sec)")
         resp_json["results"].append(result)
         resp_json["status"][result["status"]] += 1
     elapsed = timer.stop()
-    logger.info(f"Uploaded images to VecDB : "
+    logger.info(f"[{threading.get_ident()}] Uploaded images to VecDB : "
                 f"Total {resp_json['status']['success']} success, {resp_json['status']['failed']} failed "
                 f"({elapsed:.3f} sec)")
     return JSONResponse(content=resp_json)
 
 @app.get("/api/search")
 def api_search(query: str):
-    logger.info("====== /api/search ======", extra={"color_message": f"====== {click.style('/api/search', bold=True)} ======"})
+    logger.info(f"[{threading.get_ident()}] ====== /api/search ======", extra={"color_message": f"[{threading.get_ident()}] ====== {click.style('/api/search', bold=True)} ======"})
     try:
         timer = SimpleTimer()
         timer.start()
@@ -103,9 +104,9 @@ def api_search(query: str):
         resp_json = {"status": "success", "vector": feature}
         elapsed = timer.stop()
         feature_string = ", ".join([f"{v:.3f}" for v in (0, 1, 2)] + ["... "] + [f"{feature[-1]:.3f}"])
-        logger.info(f"Response text vector : \"{query}\" => (Success, {elapsed:.3f} sec) [{feature_string}]")
+        logger.info(f"[{threading.get_ident()}] Response text vector : \"{query}\" => (Success, {elapsed:.3f} sec) [{feature_string}]")
         return JSONResponse(content=resp_json)
     except Exception as e:
         resp_json = {"status": "failed", "error_msg": f"{type(e)}: {e}"}
-        logger.info(f"Response text vector : \"{query}\" => (Failed) {resp_json['error_msg']}")
+        logger.info(f"[{threading.get_ident()}] Response text vector : \"{query}\" => (Failed) {resp_json['error_msg']}")
         return JSONResponse(content=resp_json)


### PR DESCRIPTION
- 기존 로그 결과는 동시에 여러 이미지 업로드 또는 검색 요청이 들어오면 각 작업에 대한 로그가 뒤섞여버림
- FastAPI는 메인 이벤트 loop에서 각 API 호출 시 새로운 스레드를 만들어 실행
- 이를 이용하여 로그에 스레드 ID를 같이 출력함으로써, 로그가 뒤섞여도 특정 요청에 대한 로그 트래킹을 용이하게 함 